### PR TITLE
Implement SDK auto reconnect

### DIFF
--- a/OnvitechCapacitorStripeTerminal.podspec
+++ b/OnvitechCapacitorStripeTerminal.podspec
@@ -10,5 +10,5 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'StripeTerminal', '2.8.0'
+    s.dependency 'StripeTerminal', '2.11.0'
   end

--- a/OnvitechCapacitorStripeTerminal.podspec
+++ b/OnvitechCapacitorStripeTerminal.podspec
@@ -1,7 +1,7 @@
 
   Pod::Spec.new do |s|
     s.name = 'OnvitechCapacitorStripeTerminal'
-    s.version = '2.1.1'
+    s.version = '3.0.0'
     s.summary = 'Capacitor plugin for Stripe Terminal (credit card readers).'
     s.license = 'MIT'
     s.homepage = 'https://github.com/onviteam/capacitor-stripe-terminal'

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -12,6 +12,7 @@ CAP_PLUGIN(StripeTerminal, "StripeTerminal",
            CAP_PLUGIN_METHOD(getConnectionStatus, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getConnectedReader, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(cancelDiscoverReaders, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(cancelReaderReconnect, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(disconnectReader, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(installAvailableUpdate, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(cancelInstallUpdate, CAPPluginReturnPromise);

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'StripeTerminal', '2.8.0'
+  pod 'StripeTerminal', '2.11.0'
 end
 
 target 'Plugin' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Capacitor (3.2.0):
     - CapacitorCordova
   - CapacitorCordova (3.2.0)
-  - StripeTerminal (2.8.0)
+  - StripeTerminal (2.11.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - StripeTerminal (= 2.8.0)
+  - StripeTerminal (= 2.11.0)
 
 SPEC REPOS:
   trunk:
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 97ac74f937eb9cd098b067c48f2e00de62c8b3c9
   CapacitorCordova: 643fc644c43204cf1a344b19ef0423beae5ae9ff
-  StripeTerminal: 6a941bb9feec23d9933eaf330fc398cdce95e252
+  StripeTerminal: 6644ad8f766cf7b8ea8381e922c208b7d8894468
 
-PODFILE CHECKSUM: 9a3c5fc56f5e651a5af9c8d53c9cc55a75c48d63
+PODFILE CHECKSUM: 0a45310271dd87feaff6d9abe57a2575e1702eef
 
 COCOAPODS: 1.11.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onvitech/capacitor-stripe-terminal",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "Capacitor plugin for Stripe Terminal (credit card readers).",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -724,6 +724,8 @@ export interface StripeTerminalInterface {
 
   cancelDiscoverReaders(): Promise<void>
 
+  cancelReaderReconnect(): Promise<void>
+
   connectBluetoothReader(options: {
     serialNumber: string
     locationId: string
@@ -790,7 +792,7 @@ export interface StripeTerminalInterface {
   ): Promise<PluginListenerHandle> & PluginListenerHandle
 
   addListener(
-    eventName: 'didReportUnexpectedReaderDisconnect',
+    eventName: 'didReportReaderReconnectStart' | 'didReportReaderReconnectSuccess' | 'didReportReaderReconnectFail',
     listenerFunc: () => void
   ): Promise<PluginListenerHandle> & PluginListenerHandle
 


### PR DESCRIPTION
Ticket: https://www.notion.so/onvi/Handle-card-reader-auto-reconnection-364ca299bac048d7b83fedaf3195b519

Serve PR: https://github.com/onviteam/onvi-serve/pull/588

## List of changes
- [x] Upgrade SDK to `v2.11.0`
- [x] Implement SDK built-in reader reconnection flow as documented [here](https://stripe.com/docs/terminal/payments/connect-reader?terminal-sdk-platform=ios&reader-type=bluetooth#2.-automatically-attempt-reconnection)
- [x] Use thread to prevent busy error (transferred from https://github.com/eventOneHQ/capacitor-stripe-terminal/commit/f56c1acc2182ef3ecd93c288a9645b6a2fb25aff)
- [x] Bump package version to `v3.0.0` 